### PR TITLE
fix: Update Discord invitation link

### DIFF
--- a/_includes/components/header-nav.njk
+++ b/_includes/components/header-nav.njk
@@ -24,7 +24,7 @@
                 <a href="https://twitter.com/devprtcl" target="_blank">Twitter</a>
             </li>
             <li>
-                <a href="https://discord.gg/vUBmjuk" target="_blank">Discord</a>
+                <a href="https://discord.gg/VwJp4KM" target="_blank">Discord</a>
             </li>
             <li>
                 <a href="https://community.devprotocol.xyz/" target="_blank">Community</a>


### PR DESCRIPTION
Things added/changed:

- Update Discord invitation link.
  - This is the most used one, plus it has unlimited uses and unlimited time.
