### PR TITLE
Fix title and paging to match navigation

### DIFF
--- a/content/en/pages/00-Introduction/3-devtoken.md
+++ b/content/en/pages/00-Introduction/3-devtoken.md
@@ -1,5 +1,5 @@
 ---
-title: Token Overview
+title: Dev Token Overview
 date: 2021-05-07
 permalink: /{{ locale }}/introduction/devtoken/index.html
 eleventyNavigation:

--- a/content/en/pages/0000-protocol/governance/basic-concept-of-governance.md
+++ b/content/en/pages/0000-protocol/governance/basic-concept-of-governance.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/protocol/governance/basic-concept-of-governance/index.h
 eleventyNavigation:
   key: Basic concept of governance
   parent: Governance
-  order: 31
+  order: 111
   title: Basic concept of governance
 ---
 

--- a/content/en/pages/0000-protocol/governance/dips.md
+++ b/content/en/pages/0000-protocol/governance/dips.md
@@ -6,7 +6,7 @@ permalink: /{{ locale }}/protocol/governance/dips/index.html
 eleventyNavigation:
   key: DIPs
   parent: Governance
-  order: 32
+  order: 112
   title: DIPs
 ---
 

--- a/content/en/pages/0000-protocol/governance/index.md
+++ b/content/en/pages/0000-protocol/governance/index.md
@@ -6,7 +6,7 @@ eleventyNavigation:
   key: Governance
   parent: Protocol
   title: Governance
-  order: 30
+  order: 110
 ---
 
 - [Basic concept of governance](/protocol/governance/basic-concept-of-governance)

--- a/content/en/pages/0000-protocol/governance/upgrading-core-modules.md
+++ b/content/en/pages/0000-protocol/governance/upgrading-core-modules.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/protocol/governance/upgrading-core-modules/index.html
 eleventyNavigation:
   key: Upgrading core modules
   parent: Governance
-  order: 33
+  order: 113
   title: Upgrading core modules
 ---
 

--- a/content/en/pages/0000-protocol/governance/upgrading-predefined-variables.md
+++ b/content/en/pages/0000-protocol/governance/upgrading-predefined-variables.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/protocol/governance/upgrading-predefined-variables/inde
 eleventyNavigation:
   key: Upgrading predefined variables
   parent: Governance
-  order: 34
+  order: 114
   title: Upgrading predefined variables
 ---
 

--- a/content/en/pages/0000-protocol/whitepaper.md
+++ b/content/en/pages/0000-protocol/whitepaper.md
@@ -4,7 +4,7 @@ date: 2021-05-07
 permalink: /{{ locale }}/whitepaper/index.html
 eleventyNavigation:
   key: Protocol
-  order: 30
+  order: 100
   title: The Protocol whitepaper
 ---
 

--- a/content/en/pages/2000-stakes-social/dev-token-guide.md
+++ b/content/en/pages/2000-stakes-social/dev-token-guide.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/token-guide/index.html
 eleventyNavigation:
   key: DEV Token Guide
   parent: stakes-social
-  order: 2400
+  order: 2040
   title: Guideline for DEV token
 ---
 

--- a/content/en/pages/2000-stakes-social/how-to-attach-image.md
+++ b/content/en/pages/2000-stakes-social/how-to-attach-image.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/attach-image/index.html
 eleventyNavigation:
   key: Attach sToken Image (for creators)
   parent: stakes-social
-  order: 2220
+  order: 2030
   title: Attach sToken Image (for creators)
 ---
 

--- a/content/en/pages/2000-stakes-social/how-to-buy-dev.md
+++ b/content/en/pages/2000-stakes-social/how-to-buy-dev.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/how-to-buy/index.html
 eleventyNavigation:
   key: how-to-buy
   parent: stakes-social
-  order: 2100
+  order: 2010
   title: How to buy DEV
 ---
 

--- a/content/en/pages/2000-stakes-social/how-to-move-funds.md
+++ b/content/en/pages/2000-stakes-social/how-to-move-funds.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/how-to-move-funds/index.html
 eleventyNavigation:
   key: how-to-move-funds
   parent: stakes-social
-  order: 2700
+  order: 2060
   title: How to Move Funds to Arbitrum
 ---
 

--- a/content/en/pages/2000-stakes-social/how-to-stake.md
+++ b/content/en/pages/2000-stakes-social/how-to-stake.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/how-to-stake/index.html
 eleventyNavigation:
   key: how-to-stake
   parent: stakes-social
-  order: 2200
+  order: 2020
   title: How to stake your DEV on Stakes.social
 ---
 

--- a/content/en/pages/2000-stakes-social/networks-other-than-ethereum.md
+++ b/content/en/pages/2000-stakes-social/networks-other-than-ethereum.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/networks-other-than-ethereum/index.html
 eleventyNavigation:
   key: Networks other than Ethereum
   parent: stakes-social
-  order: 2600
+  order: 2050
   title: Networks other than Ethereum
 ---
 

--- a/content/en/pages/2000-stakes-social/polygon-starter.md
+++ b/content/en/pages/2000-stakes-social/polygon-starter.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/stakes-social/polygon-starter/index.html
 eleventyNavigation:
   key: Polygon Starter
   parent: stakes-social
-  order: 2900
+  order: 2070
   title: Polygon Starter
 ---
 

--- a/content/en/pages/2500-niwa/onboard-guide.md
+++ b/content/en/pages/2500-niwa/onboard-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Getting Started with Niwa
+title: How to Create a Social Token
 date: 2022-02-10
 permalink: /{{ locale }}/niwa/how-to-create-a-social-token/index.html
 eleventyNavigation:
@@ -9,7 +9,7 @@ eleventyNavigation:
   title: How to Create a Social Token
 ---
 
-## How to Create a Social Token
+## Getting Started with Niwa
 
 Social tokens are a type of cryptocurrency that is built around a creator, community, or brand. It is a way that helps Creators to monetize their works without relying on third-party platforms or agencies. With Niwa, you can issue social tokens (FT\*) specialized for creators, and freely combine them with various Dapps to start a creator economy using Web3.
 

--- a/content/en/pages/3000-developers/ecosystem-addresses.md
+++ b/content/en/pages/3000-developers/ecosystem-addresses.md
@@ -6,6 +6,6 @@ layout: layouts/ecosystem-addresses.njk
 eleventyNavigation:
   key: ecosystem-addresses
   parent: developers
-  order: 1
+  order: 3100
   title: Ecosystem addresses
 ---

--- a/content/en/pages/3000-developers/modules/overview.md
+++ b/content/en/pages/3000-developers/modules/overview.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/index.html
 eleventyNavigation:
   key: developers_modules
   parent: developers
-  order: 3100
+  order: 3200
   title: Contracts
 ---
 

--- a/content/en/pages/3000-developers/modules/v1/dev.md
+++ b/content/en/pages/3000-developers/modules/v1/dev.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/v1/dev/index.html
 eleventyNavigation:
   key: v1-dev-module
   parent: developers_modules_v1
-  order: 3110
+  order: 3211
   title: Dev
 ---
 

--- a/content/en/pages/3000-developers/modules/v1/market.md
+++ b/content/en/pages/3000-developers/modules/v1/market.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/v1/market/index.html
 eleventyNavigation:
   key: v1-market-module
   parent: developers_modules_v1
-  order: 3130
+  order: 3213
   title: Market
 ---
 

--- a/content/en/pages/3000-developers/modules/v1/overview.md
+++ b/content/en/pages/3000-developers/modules/v1/overview.md
@@ -1,10 +1,10 @@
 ---
-title: Modules
+title: V1
 date: 2021-05-07
 permalink: /{{ locale }}/developers/modules/v1/index.html
 eleventyNavigation:
   key: developers_modules_v1
   parent: developers_modules
-  order: 1000
+  order: 3210
   title: V1
 ---

--- a/content/en/pages/3000-developers/modules/v1/property.md
+++ b/content/en/pages/3000-developers/modules/v1/property.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/v1/property/index.html
 eleventyNavigation:
   key: v1-property-module
   parent: developers_modules_v1
-  order: 3120
+  order: 3212
   title: Property
 ---
 

--- a/content/en/pages/3000-developers/modules/v1/s-token-manager.md
+++ b/content/en/pages/3000-developers/modules/v1/s-token-manager.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/v1/s-token-manager/index.html
 eleventyNavigation:
   key: v1-s-token-manager-module
   parent: developers_modules_v1
-  order: 3150
+  order: 3214
   title: STokenManager
 ---
 

--- a/content/en/pages/3000-developers/modules/v2/overview.md
+++ b/content/en/pages/3000-developers/modules/v2/overview.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/v2/index.html
 eleventyNavigation:
   key: developers_modules_v2
   parent: developers_modules
-  order: 1000
+  order: 3220
   title: V2
 ---
 

--- a/content/en/pages/3000-developers/modules/v2/s-token-manager.md
+++ b/content/en/pages/3000-developers/modules/v2/s-token-manager.md
@@ -5,7 +5,7 @@ permalink: /{{ locale }}/developers/modules/v2/s-token-manager/index.html
 eleventyNavigation:
   key: v2-s-token-manager-module
   parent: developers_modules_v2
-  order: 3150
+  order: 3221
   title: STokenManager
 ---
 

--- a/content/en/pages/4000-learning/guide.md
+++ b/content/en/pages/4000-learning/guide.md
@@ -1,13 +1,15 @@
 ---
-title: Building Decentralized applications with DEV Integration
+title: Guide
 date: 2021-08-26
 permalink: /{{ locale }}/learning/learning/building-dapp-dev-integration/index.html
 eleventyNavigation:
   key: building-dapp-dev-integration
   parent: learning
   order: 4100
-  title: Building Decentralized applications with DEV Integration
+  title: Guide
 ---
+
+## Building Decentralized applications with DEV Integration
 
 The following guide and hands-on will help you to integrate DEV to your web application. In this hands-on, you don't need to worry about the gas fee in Ropsten Network. First is, we will follow the guide below before going to hands-on.
 

--- a/content/en/pages/4000-learning/hands-on 1.md
+++ b/content/en/pages/4000-learning/hands-on 1.md
@@ -1,5 +1,5 @@
 ---
-title: Connect to Metamask to authenticate and display the user's wallet address and possessed DEV
+title: Hands-on 1
 date: 2021-08-26
 permalink: /{{ locale }}/learning/learning/authenticate-and-display/index.html
 eleventyNavigation:
@@ -9,7 +9,7 @@ eleventyNavigation:
   title: Hands-on 1
 ---
 
-### Hands-on 1
+## Connect to Metamask to authenticate and display the user's wallet address and possessed DEV
 
 First, I will introduce the finished product to be created this time. Please access the following URL
 https://27v7x.csb.app/

--- a/content/en/pages/4000-learning/hands-on 2.md
+++ b/content/en/pages/4000-learning/hands-on 2.md
@@ -1,5 +1,5 @@
 ---
-title: Display registered properties and perform staking
+title: Hands-on 2
 date: 2021-08-26
 permalink: /{{ locale }}/learning/learning/display-properties-perform-staking/index.html
 eleventyNavigation:
@@ -9,7 +9,7 @@ eleventyNavigation:
   title: Hands-on 2
 ---
 
-## Hands-on #2
+## Display registered properties and perform staking
 
 This hands-on displays the projects registered in the Dev Protocol (called properties in the code). Dev Protocol data can be called by GraphQL. First, let's look at the data using GraphQL. GraphQL can be accessed from the link below.
 

--- a/content/en/pages/4000-learning/hands-on 3.md
+++ b/content/en/pages/4000-learning/hands-on 3.md
@@ -1,5 +1,5 @@
 ---
-title: List staking properties and withdraw staking
+title: Hands-on 3
 date: 2021-08-26
 permalink: /{{ locale }}/learning/learning/staking-properties-withdraw-staking/index.html
 eleventyNavigation:
@@ -9,7 +9,7 @@ eleventyNavigation:
   title: Hands-on 3
 ---
 
-### Hands-on #3
+## List staking properties and withdraw staking
 
 This hands-on get staking property information from GraphQL. First, let's get a list of staking properties using GraphQL. GraphQL can be accessed from the link below.
 

--- a/content/en/pages/4000-learning/overview.md
+++ b/content/en/pages/4000-learning/overview.md
@@ -1,5 +1,5 @@
 ---
-title: Building Decentralized applications with DEV Integration
+title: Learning
 date: 2021-08-26
 permalink: /{{ locale }}/learning/index.html
 eleventyNavigation:
@@ -7,6 +7,8 @@ eleventyNavigation:
   order: 4000
   title: Learning
 ---
+
+## Building Decentralized applications with DEV Integration
 
 The Dev Protocol new update uses Ropsten Test Network when creating decentralized applications. Developers can now continue their development without worrying about the gas fee and $DEV for the test environment.
 


### PR DESCRIPTION
### description
- "docs.devprotocol.xyz" title and paging is not matched navigation and some navigation title is not simple
- I fixed the title and paging to be more actuate and simpler

### fixed lists
| directory| fixed point |
|--|--|
|00-Introduction| fixed title |
|0000-protocol| fixed order number 3x to 1xx and some paging dees not work|
|2000-stakes-social| fixed order number 2xxx to 20xx|
|2500-niwa| fixed title to match navigation|
|3000-developers| fixed order number and some paging dees not work|
|4000-learning| fixed title to match navigation and simplified long title|

### attention
- Fixed only en version (not ja and pt)
- If this pr is ok, I will fix the other lang versions (maybe I need help to fix po...)